### PR TITLE
Fix DateTime lte operator overload

### DIFF
--- a/src/datetime/DateTime.hx
+++ b/src/datetime/DateTime.hx
@@ -664,7 +664,7 @@ abstract DateTime (Float) {
     @:op(A > B)  private inline function gt (dt:DateTime)  : Bool return getTime() > dt.getTime();
     @:op(A >= B) private inline function gte (dt:DateTime) : Bool return getTime() >= dt.getTime();
     @:op(A < B)  private inline function lt (dt:DateTime)  : Bool return getTime() < dt.getTime();
-    @:op(A <= B) private inline function lte (dt:DateTime) : Bool return getTime() < dt.getTime();
+    @:op(A <= B) private inline function lte (dt:DateTime) : Bool return getTime() <= dt.getTime();
     @:op(A == B) private inline function eq (dt:DateTime)  : Bool return getTime() == dt.getTime();
     @:op(A != B) private inline function neq (dt:DateTime) : Bool return getTime() != dt.getTime();
 

--- a/test/DateTimeTest.hx
+++ b/test/DateTimeTest.hx
@@ -528,6 +528,25 @@ class DateTimeTest extends TestCase {
     }//function testFromIso8601String()
 
 
+    public function testComparisons () : Void {
+        var A : DateTime = '2015-10-24T00:00:00Z';
+        var B : DateTime = '2015-10-25T00:00:00Z';
+
+        assertFalse(A > B);
+        assertFalse(A >= B);
+        assertTrue(A < B);
+        assertTrue(A <= B);
+        assertFalse(A == B);
+        assertTrue(A != B);
+
+        assertFalse(A > A);
+        assertTrue(A >= A);
+        assertFalse(A < A);
+        assertTrue(A <= A);
+        assertTrue(A == A);
+        assertFalse(A != A);
+    }
+
 /**
 * :WARNING: These tests take A LOT of time.
 */


### PR DESCRIPTION
The "lte" operator overload was implemented as "<" instead of "<="