### PR TITLE
bugfix: Also consider 'negative' flag when comparing 'DateTimeInterval's

### DIFF
--- a/src/datetime/DateTimeInterval.hx
+++ b/src/datetime/DateTimeInterval.hx
@@ -150,12 +150,26 @@ abstract DateTimeInterval (DateTimeIntervalCore) to DateTimeIntervalCore from Da
     * DateTimeInterval comparison
     *
     */
-    @:op(A == B) private inline function eq (dtic:DateTimeInterval)  return this.getTotalSeconds() == dtic.getTotalSeconds();
-    @:op(A > B) private inline function gt (dtic:DateTimeInterval)   return this.getTotalSeconds() > dtic.getTotalSeconds();
-    @:op(A >= B) private inline function gte (dtic:DateTimeInterval) return this.getTotalSeconds() >= dtic.getTotalSeconds();
-    @:op(A < B)  private inline function lt (dtic:DateTimeInterval)  return this.getTotalSeconds() < dtic.getTotalSeconds();
-    @:op(A <= B) private inline function lte (dtic:DateTimeInterval) return this.getTotalSeconds() <= dtic.getTotalSeconds();
-    @:op(A != B) private inline function neq (dtic:DateTimeInterval) return this.getTotalSeconds() != dtic.getTotalSeconds();
+    @:op(A == B) private inline function eq (dtic:DateTimeInterval) {
+        return this.negative == dtic.negative
+            && this.getTotalSeconds() == dtic.getTotalSeconds();
+    }
+
+    @:op(A > B) private inline function gt (dtic:DateTimeInterval) {
+        if (!this.negative && dtic.negative)
+            return true;
+
+        if (this.negative && !dtic.negative)
+            return false;
+
+        var delta = this.getTotalSeconds() - dtic.getTotalSeconds();
+        return this.negative ? delta < 0 : delta > 0;
+    }
+
+    @:op(A >= B) private inline function gte (dtic:DateTimeInterval) return eq(dtic) || gt(dtic);
+    @:op(A < B)  private inline function lt (dtic:DateTimeInterval)  return !gte(dtic);
+    @:op(A <= B) private inline function lte (dtic:DateTimeInterval) return !gt(dtic);
+    @:op(A != B) private inline function neq (dtic:DateTimeInterval) return !eq(dtic);
 
 
     // /**

--- a/test/DateTimeIntervalTest.hx
+++ b/test/DateTimeIntervalTest.hx
@@ -56,19 +56,67 @@ class DateTimeIntervalTest extends TestCase {
         var end   : DateTime = '2014-10-03 12:24:48';
         var end2  : DateTime = '2014-10-04 12:24:48';
 
-        assertTrue(end - begin == end - begin);
-        assertFalse(end - begin != end - begin);
-        assertTrue(end - begin >= end - begin);
-        assertTrue(end - begin <= end - begin);
-        assertFalse(end - begin > end - begin);
-        assertFalse(end - begin < end - begin);
+        //negative
+		{
+			assertTrue((begin - end).negative);
+			assertFalse((end - begin).negative);
+		}
 
-        assertFalse(end2 - begin == end - begin);
-        assertTrue(end2 - begin != end - begin);
-        assertTrue(end2 - begin >= end - begin);
-        assertFalse(end2 - begin <= end - begin);
-        assertTrue(end2 - begin > end - begin);
-        assertFalse(end2 - begin < end - begin);
+		//eq
+		{
+			assertTrue(begin - end == begin - end);
+			assertTrue(end - begin == end - begin);
+			assertFalse(begin - end == end - begin);
+			assertFalse(end - begin == begin - end);
+		}
+
+		//gt
+		{
+			assertTrue(end - begin > begin - end);
+			assertTrue(end2 - begin > end - begin);
+			assertFalse(begin - end > end - begin);
+			assertFalse(end - begin > end2 - begin);
+			assertFalse(begin - end > begin - end);
+		}
+
+		//gte
+		{
+			assertTrue(end - begin >= begin - end);
+			assertTrue(end2 - begin >= end - begin);
+			assertFalse(begin - end >= end - begin);
+			assertFalse(end - begin >= end2 - begin);
+
+			assertTrue(begin - end >= begin - end);
+			assertTrue(end - begin >= end - begin);
+		}
+
+		//lt
+		{
+			assertTrue(begin - end < end - begin);
+			assertTrue(end - begin < end2 - begin);
+			assertFalse(end - begin < begin - end);
+			assertFalse(end2 - begin < end - begin);
+			assertFalse(begin - end < begin - end);
+		}
+
+		//lte
+		{
+			assertTrue(begin - end <= end - begin);
+			assertTrue(end - begin <= end2 - begin);
+			assertFalse(end - begin <= begin - end);
+			assertFalse(end2 - begin <= end - begin);
+
+			assertTrue(begin - end <= begin - end);
+			assertTrue(end - begin <= end - begin);
+		}
+
+		//neq
+		{
+			assertFalse(begin - end != begin - end);
+			assertFalse(end - begin != end - begin);
+			assertTrue(begin - end != end - begin);
+			assertTrue(end - begin != begin - end);
+		}
     }//function testComparison()
 
 


### PR DESCRIPTION
Currently, comparison doesn't work with mixed negative and positive 'DateTimeInterval's.